### PR TITLE
Fix the C include paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(GENERATED): $(GENERATOR)
 	$(BUILDDIR)/generate $(BUILDDIR)/generated
 
 $(BUILDDIR)/%.o: %.c
-	gcc -c -o $@ -fPIC -I $(shell ocamlfind query ctypes) -I $(OCAMLDIR)/../ctypes $<
+	gcc -c -o $@ -fPIC -I $(shell ocamlfind query ctypes) -I $(OCAMLDIR) -I $(OCAMLDIR)/../ctypes $<
 
 $(BUILDDIR)/%.cmx: %.ml
 	ocamlfind opt -c -o $@ -I $(BUILDDIR)/generated -I $(BUILDDIR)/lib -package $(PACKAGES) $<

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(GENERATED): $(GENERATOR)
 	$(BUILDDIR)/generate $(BUILDDIR)/generated
 
 $(BUILDDIR)/%.o: %.c
-	gcc -c -o $@ -fPIC -I $(OCAMLDIR)/../ctypes $<
+	gcc -c -o $@ -fPIC -I $(shell ocamlfind query ctypes) -I $(OCAMLDIR)/../ctypes $<
 
 $(BUILDDIR)/%.cmx: %.ml
 	ocamlfind opt -c -o $@ -I $(BUILDDIR)/generated -I $(BUILDDIR)/lib -package $(PACKAGES) $<

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,6 @@
 BUILDDIR=../_build/test
 $(shell mkdir -p $(BUILDDIR))
+OCAMLDIR=$(shell ocamlopt -where)
 CC=gcc
 LD=gcc
 
@@ -12,6 +13,6 @@ $(BUILDDIR)/test.native: $(BUILDDIR)/test.o
 	$(LD) -o $@ $< -L$(BUILDDIR)/.. -lxmlm
 
 $(BUILDDIR)/test.o: test.c
-	$(CC) -c -o $@ -I $(BUILDDIR)/../generated  $<
+	$(CC) -c -o $@ -I $(OCAMLDIR) -I $(BUILDDIR)/../generated  $<
 
 .PHONY: all clean


### PR DESCRIPTION
These patches make the compile work (not link -- more info to follow) on OSX where
- `ocaml` comes from home-brew and headers are in /usr/local
- `ctypes` comes from ocaml and headers are in `~/.opam/somewhere`
