### PR TITLE
Add basic Appveyor configuration.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
 
 install:
     - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
-    - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P wget  -P dos2unix -P diffutils -P cpio -P make -P patch -P mingw64-%MINGW_ARCH%-gcc-core -P mingw64-%MINGW_ARCH%-gcc-g++ >NUL'
+    - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P wget  -P dos2unix -P diffutils -P make -P patch -P mingw64-%MINGW_ARCH%-gcc-core -P mingw64-%MINGW_ARCH%-gcc-g++ -P git -P m4 -P rsync -P unzip -P curl >NUL'
     - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin"'
     - 'appveyor DownloadFile %OPAM_URL% -FileName opam.tar.xz'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+platform:
+    - x64
+
+environment:
+    global:
+        CYG_MIRROR: http://cygwin.uib.no
+        CYG_CACHE: C:/cygwin/var/cache/setup
+    matrix:
+        -   CYG_ARCH: x86
+            CYG_ROOT: C:/cygwin
+            WODI_ARCH: 32
+            MINGW_ARCH: i686
+            OPAM_URL: https://dl.dropboxusercontent.com/s/eo4igttab8ipyle/opam32.tar.xz
+        -   CYG_ARCH: x86_64
+            CYG_ROOT: C:/cygwin64
+            WODI_ARCH: 64
+            MINGW_ARCH: x86_64
+            OPAM_URL: https://dl.dropboxusercontent.com/s/b2q2vjau7if1c1b/opam64.tar.xz
+
+init:
+    - 'echo System architecture: %PLATFORM%'
+
+install:
+    - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
+    - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P wget  -P dos2unix -P diffutils -P cpio -P make -P patch -P mingw64-%MINGW_ARCH%-gcc-core -P mingw64-%MINGW_ARCH%-gcc-g++ >NUL'
+    - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin"'
+    - 'appveyor DownloadFile %OPAM_URL% -FileName opam.tar.xz'
+
+
+build_script:
+    - '%CYG_ROOT%/bin/bash -lc "cd \"$OLDPWD\" && ./appveyor/build.sh"'
+
+artifacts:
+  - path: test.log
+    name: test-logs

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -9,13 +9,13 @@ case "$x" in
         build=x86_64-pc-cygwin
         host=x86_64-w64-mingw32
         MINGW_TOOL_PREFIX=${host}-
-	SWITCH=4.02.3+mingw64
+	SWITCH=4.02.3+mingw64c
         ;;
     *)
         build=i686-pc-cygwin
         host=i686-w64-mingw32
         MINGW_TOOL_PREFIX=${host}-
-	SWITCH=4.02.3+mingw32
+	SWITCH=4.02.3+mingw32c
         ;;
 esac
 
@@ -47,7 +47,9 @@ tar xf opam.tar.xz
 bash opam*/install.sh
 opam init mingw 'https://github.com/fdopen/opam-repository-mingw.git' --comp ${SWITCH} --switch ${SWITCH}
 eval `opam config env`
-opam install depext depext-cygwinports
-opam depext ctypes-foreign
+#opam install depext depext-cygwinports
+opam install depext-cygwinports
+# opam depext ctypes-foreign
+cygwin-install install libffi pkg-config
 opam install --verbose ctypes-foreign ctypes xmlm
 make && make test

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -ex
+
+export OPAMYES=1
+
+x="$(uname -m)"
+case "$x" in
+    x86_64)
+        build=x86_64-pc-cygwin
+        host=x86_64-w64-mingw32
+        MINGW_TOOL_PREFIX=${host}-
+	SWITCH=4.02.3+mingw64
+        ;;
+    *)
+        build=i686-pc-cygwin
+        host=i686-w64-mingw32
+        MINGW_TOOL_PREFIX=${host}-
+	SWITCH=4.02.3+mingw32
+        ;;
+esac
+
+export AR=${MINGW_TOOL_PREFIX}ar.exe
+export AS=${MINGW_TOOL_PREFIX}as.exe
+export CC=${MINGW_TOOL_PREFIX}gcc.exe
+export CPP=${MINGW_TOOL_PREFIX}cpp.exe
+export CPPFILT=${MINGW_TOOL_PREFIX}c++filt.exe
+export CXX=${MINGW_TOOL_PREFIX}g++.exe
+export DLLTOOL=${MINGW_TOOL_PREFIX}dlltool.exe
+export DLLWRAP=${MINGW_TOOL_PREFIX}dllwrap.exe
+export GCOV=${MINGW_TOOL_PREFIX}gcov.exe
+export LD=${MINGW_TOOL_PREFIX}ld.exe
+export NM=${MINGW_TOOL_PREFIX}nm.exe
+export OBJCOPY=${MINGW_TOOL_PREFIX}objcopy.exe
+export OBJDUMP=${MINGW_TOOL_PREFIX}objdump.exe
+export RANLIB=${MINGW_TOOL_PREFIX}ranlib.exe
+export RC=${MINGW_TOOL_PREFIX}windres.exe
+export READELF=${MINGW_TOOL_PREFIX}readelf.exe
+export SIZE=${MINGW_TOOL_PREFIX}size.exe
+export STRINGS=${MINGW_TOOL_PREFIX}strings.exe
+export STRIP=${MINGW_TOOL_PREFIX}strip.exe
+export WINDMC=${MINGW_TOOL_PREFIX}windmc.exe
+export WINDRES=${MINGW_TOOL_PREFIX}windres.exe
+
+export PATH=/usr/$host/sys-root/mingw/bin:$PATH
+
+tar xf opam.tar.xz
+bash opam*/install.sh
+opam init mingw 'https://github.com/fdopen/opam-repository-mingw.git' --comp ${SWITCH} --switch ${SWITCH}
+eval `opam config env`
+opam install depext depext-cygwinports
+opam depext ctypes-foreign
+opam install --verbose ctypes-foreign ctypes xmlm
+make && make test

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,9 @@
 BUILDDIR=../_build/test
 $(shell mkdir -p $(BUILDDIR))
 OCAMLDIR=$(shell ocamlopt -where)
-CC=gcc
-LD=gcc
+
+CC:= $(shell ocamlfind ocamlc -config | awk '/^bytecomp_c_compiler/ {for(i=2;i<=NF;i++) printf "%s " ,$$i}')
+LD=$(CC)
 
 all: $(BUILDDIR)/test.native
 


### PR DESCRIPTION
Based on @fdopen's [opam-repository-mingw](https://github.com/fdopen/opam-repository-mingw).

This isn't ready to merge: it's not yet working, since the ctypes build fails to find libffi.  From the [logs](https://ci.appveyor.com/project/yallop/ocaml-ctypes-inverted-stubs-example/build/1.0.10/job/4b09ofu9gt2crntj#L311) it appears that commands are executed out of order:

```
[ctypes: make ctypes-base] Command started
+ make "XEN=disable" "ctypes-base" "ctypes-stubs" (CWD=C:/cygwin/home/appveyor/.opam/4.02.3+mingw32/build/ctypes.0.4.1)
Downloaded C:\cygwin\packages/ftp%3a%2f%2fftp.gwdg.de%2fpub%2flinux%2fsources.redhat.com%2fcygwinports%2f/noarch/release/mingw64-i686-libffi/mingw64-i686-libffi-3.2.1-1.tar.xz
Extracting from file://C:\cygwin\packages/ftp%3a%2f%2fftp.gwdg.de%2fpub%2flinux%2fsources.redhat.com%2fcygwinports%2f/noarch/release/mingw64-i686-libffi/mingw64-i686-libffi-3.2.1-1.tar.xz
```

Perhaps opam is spawning child processes and not waiting for them to complete, or perhaps the logs are misleading.
