### PR TITLE
Update build.sh

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
 
 install:
     - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
-    - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P wget  -P dos2unix -P diffutils -P cpio -P make -P patch -P mingw64-%MINGW_ARCH%-gcc-core -P mingw64-%MINGW_ARCH%-gcc-g++ >NUL'
+    - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P wget  -P dos2unix -P diffutils -P make -P patch -P mingw64-%MINGW_ARCH%-gcc-core -P mingw64-%MINGW_ARCH%-gcc-g++ -P git -P m4 -P rsync -P unzip -P curl >NUL'
     - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin"'
     - 'appveyor DownloadFile %OPAM_URL% -FileName opam.tar.xz'
 

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -9,13 +9,13 @@ case "$x" in
         build=x86_64-pc-cygwin
         host=x86_64-w64-mingw32
         MINGW_TOOL_PREFIX=${host}-
-	SWITCH=4.02.3+mingw64
+	SWITCH=4.02.3+mingw64c
         ;;
     *)
         build=i686-pc-cygwin
         host=i686-w64-mingw32
         MINGW_TOOL_PREFIX=${host}-
-	SWITCH=4.02.3+mingw32
+	SWITCH=4.02.3+mingw32c
         ;;
 esac
 
@@ -47,7 +47,9 @@ tar xf opam.tar.xz
 bash opam*/install.sh
 opam init mingw 'https://github.com/fdopen/opam-repository-mingw.git' --comp ${SWITCH} --switch ${SWITCH}
 eval `opam config env`
-opam install depext depext-cygwinports
-opam depext ctypes-foreign
+#opam install depext depext-cygwinports
+opam install depext-cygwinports
+# opam depext ctypes-foreign
+cygwin-install install libffi pkg-config
 opam install --verbose ctypes-foreign ctypes xmlm
 make && make test

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,9 @@
 BUILDDIR=../_build/test
 $(shell mkdir -p $(BUILDDIR))
 OCAMLDIR=$(shell ocamlopt -where)
-CC=gcc
-LD=gcc
+
+CC:= $(shell ocamlfind ocamlc -config | awk '/^bytecomp_c_compiler/ {for(i=2;i<=NF;i++) printf "%s " ,$$i}')
+LD=$(CC)
 
 all: $(BUILDDIR)/test.native
 


### PR DESCRIPTION
Yes, it is indeed broken.
opam depext returns instantly and the job is executed in background. For the moment, I've replaced 'opam depext' with the command executed by 'opam depext'. 

I've also configured it to use a pre-compiled OCaml version (faster builds).
