### PR TITLE
Workaround to construct a proper library under OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,13 @@ sharedlib: $(BUILDDIR)/libxmlm$(EXTDLL)
 
 
 ifeq ($(OSTYPE),$(filter $(OSTYPE),Win32 Cygwin))
-$(BUILDDIR)/libxmlm$(EXTDLL): $(LIBFILES)
+$(BUILDDIR)/libxmlm$(EXTDLL): $(CAML_INIT) $(LIBFILES)
 	ocamlfind opt -o $@ -linkpkg -output-obj -verbose -package $(PACKAGES) $^
 else ifeq ($(SYSTEM),$(filter $(SYSTEM),macosx))
 $(BUILDDIR)/libxmlm$(EXTDLL): $(CAML_INIT) $(LIBFILES)
 	ocamlfind opt -o $@ -linkpkg -runtime-variant _pic -verbose -ccopt -dynamiclib -package $(PACKAGES) $^
 else
-$(BUILDDIR)/libxmlm$(EXTDLL): $(LIBFILES)
+$(BUILDDIR)/libxmlm$(EXTDLL): $(CAML_INIT) $(LIBFILES)
 	ocamlfind opt -o $@ -linkpkg -output-obj -runtime-variant _pic -verbose -package $(PACKAGES) $^
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILDDIR=_build
 VPATH=$(BUILDDIR)
 OCAMLDIR=$(shell ocamlopt -where)
-$(shell mkdir -p $(BUILDDIR) $(BUILDDIR)/lib $(BUILDDIR)/stub_generator $(BUILDDIR)/test $(BUILDDIR)/generated)
+$(shell mkdir -p $(BUILDDIR) $(BUILDDIR)/stub $(BUILDDIR)/lib $(BUILDDIR)/stub_generator $(BUILDDIR)/test $(BUILDDIR)/generated)
 PACKAGES=xmlm,ctypes.stubs,ctypes.foreign
 
 # The files used to build the stub generator.
@@ -14,12 +14,15 @@ LIBFILES=$(BUILDDIR)/lib/bindings.cmx			\
          $(BUILDDIR)/lib/apply_bindings.cmx		\
          $(BUILDDIR)/generated/xmlm.o
 
+CAML_INIT=$(BUILDDIR)/stub/init.o
+
 # The files that we'll generate
 GENERATED=$(BUILDDIR)/generated/xmlm.h \
           $(BUILDDIR)/generated/xmlm.c \
           $(BUILDDIR)/generated/xmlm_bindings.ml
 
 OSTYPE:=$(shell ocamlfind ocamlc -config | awk '/^os_type:/ {print $$2}')
+SYSTEM:=$(shell ocamlfind ocamlc -config | awk '/^system:/ {print $$2}')
 EXTDLL:=$(shell ocamlfind ocamlc -config | awk '/^ext_dll:/ {print $$2}')
 CC:= $(shell ocamlfind ocamlc -config | awk '/^bytecomp_c_compiler/ {for(i=2;i<=NF;i++) printf "%s " ,$$i}')
 
@@ -39,12 +42,19 @@ sharedlib: $(BUILDDIR)/libxmlm$(EXTDLL)
 ifeq ($(OSTYPE),$(filter $(OSTYPE),Win32 Cygwin))
 $(BUILDDIR)/libxmlm$(EXTDLL): $(LIBFILES)
 	ocamlfind opt -o $@ -linkpkg -output-obj -verbose -package $(PACKAGES) $^
+else ifeq ($(SYSTEM),$(filter $(SYSTEM),macosx))
+$(BUILDDIR)/libxmlm$(EXTDLL): $(CAML_INIT) $(LIBFILES)
+	ocamlfind opt -o $@ -linkpkg -runtime-variant _pic -verbose -ccopt -dynamiclib -package $(PACKAGES) $^
 else
 $(BUILDDIR)/libxmlm$(EXTDLL): $(LIBFILES)
 	ocamlfind opt -o $@ -linkpkg -output-obj -runtime-variant _pic -verbose -package $(PACKAGES) $^
 endif
 
 stubs: $(GENERATED)
+
+$(BUILDDIR)/stub/%.o:
+	ocamlc -g -c stub/init.c
+	mv init.o $@
 
 $(GENERATED): $(GENERATOR)
 	$(GENERATOR) $(BUILDDIR)/generated

--- a/stub/init.c
+++ b/stub/init.c
@@ -1,0 +1,9 @@
+#include <caml/callback.h>
+
+__attribute__ ((__constructor__))
+void
+init(void)
+{
+  char *caml_argv[1] = { NULL };
+  caml_startup(caml_argv);
+}

--- a/test/test.c
+++ b/test/test.c
@@ -45,10 +45,6 @@ int main(int argc, char **argv)
   };
   char *filename = argc < 2 ? "/dev/stdin" : argv[1];
 
-  /* Initialize the OCaml runtime before calling the library. */
-  char *caml_argv[1] = { NULL };
-  caml_startup(caml_argv);
-
   /* Call xmlm via the exported C function */
   parse_xml(&h, filename);
   return EXIT_SUCCESS;


### PR DESCRIPTION
As discussed in #4, this PR is a workaround to make this work under OSX.

The main culprit is the use of `-output-obj` when calling `ocamlopt`. On OSX, it defaults to the use of `- bundle`, and OSX bundles can't be linked to an executable.

A simple fix is to detect the system as OSX and remove the use of `-output-obj` with `-dynamiclib`

However, to link properly, we need to add a C stub somewhere that initialize the Caml runtime… so I created `stub/init.c` and patched the Makefile to compile it properly.

`make test` seems to pass properly, I'm not too sure about why init.c is needed during the linking, maybe there is something better to do, but for now that's the solution I came with.

The changes might be a bit clunky so any feedbacks are welcome. :)
